### PR TITLE
Unexport functions

### DIFF
--- a/main.go
+++ b/main.go
@@ -68,9 +68,9 @@ func listen(listenerNum int, errors chan<- error) {
 	}
 
 	if Opts.Protocol == "tcp" {
-		TCPListen(&listenConfig, logger, errors)
+		tcpListen(&listenConfig, logger, errors)
 	} else {
-		UDPListen(&listenConfig, logger, errors)
+		udpListen(&listenConfig, logger, errors)
 	}
 }
 
@@ -130,7 +130,7 @@ func main() {
 	}
 
 	var err error
-	if Opts.ListenAddr, err = ParseHostPort(Opts.ListenAddrStr); err != nil {
+	if Opts.ListenAddr, err = parseHostPort(Opts.ListenAddrStr); err != nil {
 		Opts.Logger.Error("listen address is malformed", "error", err)
 		os.Exit(1)
 	}

--- a/utils.go
+++ b/utils.go
@@ -19,7 +19,7 @@ const (
 	UDP
 )
 
-func CheckOriginAllowed(remoteIP net.IP) bool {
+func checkOriginAllowed(remoteIP net.IP) bool {
 	if len(Opts.AllowedSubnets) == 0 {
 		return true
 	}
@@ -32,7 +32,7 @@ func CheckOriginAllowed(remoteIP net.IP) bool {
 	return false
 }
 
-func ParseHostPort(hostport string) (netip.AddrPort, error) {
+func parseHostPort(hostport string) (netip.AddrPort, error) {
 	host, portStr, err := net.SplitHostPort(hostport)
 	if err != nil {
 		return netip.AddrPort{}, fmt.Errorf("failed to parse host and port: %w", err)
@@ -55,7 +55,7 @@ func ParseHostPort(hostport string) (netip.AddrPort, error) {
 	return netip.AddrPortFrom(ip, uint16(port)), nil
 }
 
-func DialUpstreamControl(sport int) func(string, string, syscall.RawConn) error {
+func dialUpstreamControl(sport int) func(string, string, syscall.RawConn) error {
 	return func(network, address string, c syscall.RawConn) error {
 		var syscallErr error
 		err := c.Control(func(fd uintptr) {


### PR DESCRIPTION
As this is not meant to be used as a library, there is no need to export funcs or variables. Unexport them.