### PR TITLE
add -dynamic-destination flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Usage of ./go-mmproxy:
     	Path to a file that contains allowed subnets of the proxy servers
   -close-after int
     	Number of seconds after which UDP socket will be cleaned up (default 60)
+  -dynamic-destination
+        Traffic will be forwarded to the destination specified in the PROXY protocol header
   -l string
     	Address the proxy listens on (default "0.0.0.0:8443")
   -listeners int

--- a/main.go
+++ b/main.go
@@ -36,6 +36,7 @@ func init() {
 	flag.StringVar(&listenAddrStr, "l", "0.0.0.0:8443", "Address the proxy listens on")
 	flag.StringVar(&targetAddr4Str, "4", "127.0.0.1:443", "Address to which IPv4 traffic will be forwarded to")
 	flag.StringVar(&targetAddr6Str, "6", "[::1]:443", "Address to which IPv6 traffic will be forwarded to")
+	flag.BoolVar(&opts.DynamicDestination, "dynamic-destination", false, "Traffic will be forwarded to the destination specified in the PROXY protocol header")
 	flag.IntVar(&opts.Mark, "mark", 0, "The mark that will be set on outbound packets")
 	flag.IntVar(&opts.Verbose, "v", 0, `0 - no logging of individual connections
 1 - log errors occurring in individual connections
@@ -44,7 +45,7 @@ func init() {
 		"Path to a file that contains allowed subnets of the proxy servers")
 	flag.IntVar(&listeners, "listeners", 1,
 		"Number of listener sockets that will be opened for the listen address (Linux 3.9+)")
-	flag.IntVar(&udpCloseAfterInt, "close-after", 60, "Number of seconds after which UDP socket will be cleaned up")
+	flag.IntVar(&udpCloseAfterInt, "close-after", 60, "Number of seconds after which UDP socket will be cleaned up on inactivity")
 }
 
 func listen(ctx context.Context, listenerNum int, parentLogger *slog.Logger, listenErrors chan<- error) {

--- a/tcp/tcp.go
+++ b/tcp/tcp.go
@@ -52,7 +52,7 @@ func handleConnection(conn net.Conn, opts *utils.Options, logger *slog.Logger) {
 		return
 	}
 
-	saddr, _, restBytes, err := proxyprotocol.ReadRemoteAddr(buffer[:n], utils.TCP)
+	saddr, daddr, restBytes, err := proxyprotocol.ReadRemoteAddr(buffer[:n], utils.TCP)
 	if err != nil {
 		logger.Debug("failed to parse PROXY header", "error", err, slog.Bool("dropConnection", true))
 		return
@@ -60,7 +60,9 @@ func handleConnection(conn net.Conn, opts *utils.Options, logger *slog.Logger) {
 
 	targetAddr := opts.TargetAddr6
 	if saddr.IsValid() {
-		if saddr.Addr().Is4() {
+		if opts.DynamicDestination && daddr.IsValid() {
+			targetAddr = daddr
+		} else if saddr.Addr().Is4() {
 			targetAddr = opts.TargetAddr4
 		}
 	} else {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -22,14 +22,15 @@ const (
 )
 
 type Options struct {
-	Protocol       Protocol
-	ListenAddr     netip.AddrPort
-	TargetAddr4    netip.AddrPort
-	TargetAddr6    netip.AddrPort
-	Mark           int
-	Verbose        int
-	AllowedSubnets []netip.Prefix
-	UDPCloseAfter  time.Duration
+	Protocol           Protocol
+	ListenAddr         netip.AddrPort
+	TargetAddr4        netip.AddrPort
+	TargetAddr6        netip.AddrPort
+	DynamicDestination bool
+	Mark               int
+	Verbose            int
+	AllowedSubnets     []netip.Prefix
+	UDPCloseAfter      time.Duration
 }
 
 func CheckOriginAllowed(remoteIP netip.Addr, allowedSubnets []netip.Prefix) bool {


### PR DESCRIPTION
> Hi!
>
> We've a setup where multiple services should be available in the destination host. This flag allow the client to select the desired port in the PROXY protocol header.
>
> Of course, the client should be trusted for this to work without security issues (in our case, its our frontal TCP reverse-proxy).
>
> Any comment is welcome, and thanks for this helpful little tool! ;)

By @Xfennec at https://github.com/path-network/go-mmproxy/pull/15