### PR TITLE
Additional validation for PROXY headers

### DIFF
--- a/internal/proxyprotocol/proxyprotocol.go
+++ b/internal/proxyprotocol/proxyprotocol.go
@@ -11,6 +11,8 @@ import (
 	"errors"
 	"fmt"
 	"net/netip"
+	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/kzemek/go-mmproxy/internal/utils"
@@ -18,14 +20,15 @@ import (
 
 var (
 	// Proxy Protocol V2 errors
-	ErrUnknownProcotolVersion  = errors.New("unknown protocol version")
-	ErrUnknownCommand          = errors.New("unknown command")
-	ErrInvalidFamily           = errors.New("invalid family")
-	ErrInvalidProtocol         = errors.New("invalid protocol")
-	ErrDecodeAddressDataLength = errors.New("failed to decode address data length")
-	ErrIncompleteProxyHeader   = errors.New("incomplete PROXY header")
-	ErrDecodeSourcePort        = errors.New("failed to decode source port")
-	ErrDecodeDestinationPort   = errors.New("failed to decode destination port")
+	ErrUnknownProcotolVersion   = errors.New("unknown protocol version")
+	ErrUnknownCommand           = errors.New("unknown command")
+	ErrInvalidFamily            = errors.New("invalid family")
+	ErrInvalidProtocol          = errors.New("invalid protocol")
+	ErrDecodeAddressDataLength  = errors.New("failed to decode address data length")
+	ErrInvalidAddressDataLength = errors.New("invalid address data length")
+	ErrIncompleteProxyHeader    = errors.New("incomplete PROXY header")
+	ErrDecodeSourcePort         = errors.New("failed to decode source port")
+	ErrDecodeDestinationPort    = errors.New("failed to decode destination port")
 
 	// Proxy Protocol V1 errors
 	ErrNoTerminator            = errors.New("did not find \\r\\n in first data segment")
@@ -33,6 +36,8 @@ var (
 	ErrUnknownProtocol         = errors.New("unknown protocol")
 	ErrParseSourceAddress      = errors.New("failed to parse source address")
 	ErrParseDestinationAddress = errors.New("failed to parse destination address")
+	ErrParseAddress            = errors.New("failed to parse address")
+	ErrProtocolAddrMismatch    = errors.New("protocol address mismatch")
 
 	// Common errors
 	ErrInvalidSourcePort      = errors.New("invalid source port")
@@ -96,6 +101,12 @@ func readRemoteAddrPROXYv2(ctrlBuf []byte, expectedProtocol utils.Protocol) (*pr
 	if len(ctrlBuf) < 16+int(dataLen) {
 		return nil, ErrIncompleteProxyHeader
 	}
+	if addressFamily == addressFamilyInet && dataLen < 12 {
+		return nil, fmt.Errorf("%w: %d", ErrInvalidAddressDataLength, dataLen)
+	}
+	if addressFamily == addressFamilyInet6 && dataLen < 36 {
+		return nil, fmt.Errorf("%w: %d", ErrInvalidAddressDataLength, dataLen)
+	}
 
 	if command == commandLocal {
 		return &proxyHeader{
@@ -103,12 +114,18 @@ func readRemoteAddrPROXYv2(ctrlBuf []byte, expectedProtocol utils.Protocol) (*pr
 		}, nil
 	}
 
-	var sport, dport uint16
+	var srcIP, dstIP netip.Addr
 	if addressFamily == addressFamilyInet {
+		srcIP, _ = netip.AddrFromSlice(ctrlBuf[16:20])
+		dstIP, _ = netip.AddrFromSlice(ctrlBuf[20:24])
 		reader = bytes.NewReader(ctrlBuf[24:])
 	} else {
+		srcIP, _ = netip.AddrFromSlice(ctrlBuf[16:32])
+		dstIP, _ = netip.AddrFromSlice(ctrlBuf[32:48])
 		reader = bytes.NewReader(ctrlBuf[48:])
 	}
+
+	var sport, dport uint16
 	if err := binary.Read(reader, binary.BigEndian, &sport); err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrDecodeSourcePort, err)
 	}
@@ -120,15 +137,6 @@ func readRemoteAddrPROXYv2(ctrlBuf []byte, expectedProtocol utils.Protocol) (*pr
 	}
 	if dport == 0 {
 		return nil, fmt.Errorf("%w %d", ErrInvalidDestinationPort, dport)
-	}
-
-	var srcIP, dstIP netip.Addr
-	if addressFamily == addressFamilyInet {
-		srcIP, _ = netip.AddrFromSlice(ctrlBuf[16:20])
-		dstIP, _ = netip.AddrFromSlice(ctrlBuf[20:24])
-	} else {
-		srcIP, _ = netip.AddrFromSlice(ctrlBuf[16:32])
-		dstIP, _ = netip.AddrFromSlice(ctrlBuf[32:48])
 	}
 
 	return &proxyHeader{
@@ -145,51 +153,37 @@ func readRemoteAddrPROXYv1(ctrlBuf []byte) (*proxyHeader, error) {
 		return nil, ErrNoTerminator
 	}
 
-	var headerProtocol string
-	numItemsParsed, err := fmt.Sscanf(str, "PROXY %s", &headerProtocol)
-	if err != nil {
-		return nil, fmt.Errorf("%w: %w", ErrInvalidFormat, err)
+	parts := strings.Split(str[:idx], " ")
+	if slices.Contains(parts, "") || len(parts) < 2 || len(parts) > 6 || parts[0] != "PROXY" {
+		return nil, fmt.Errorf("%w", ErrInvalidFormat)
 	}
-	if numItemsParsed != 1 {
-		return nil, ErrInvalidFormat
-	}
+
+	headerProtocol := parts[1]
 	if headerProtocol == "UNKNOWN" {
-		return &proxyHeader{
-			TrailingData: ctrlBuf[idx+2:],
-		}, nil
+		return &proxyHeader{TrailingData: ctrlBuf[idx+2:]}, nil
 	}
 	if headerProtocol != "TCP4" && headerProtocol != "TCP6" {
 		return nil, fmt.Errorf("%w %s", ErrUnknownProtocol, headerProtocol)
 	}
+	if len(parts) != 6 {
+		return nil, fmt.Errorf("%w", ErrInvalidFormat)
+	}
 
-	var src, dst string
-	var sportInt, dportInt int
-	numItemsParsed, err = fmt.Sscanf(
-		str,
-		"PROXY %s %s %s %d %d",
-		&headerProtocol, &src, &dst, &sportInt, &dportInt,
-	)
+	srcIP, err := parseAddress(parts[2], headerProtocol)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %w", ErrInvalidFormat, err)
+		return nil, fmt.Errorf("%w %s: %w", ErrParseSourceAddress, parts[2], err)
 	}
-	if numItemsParsed != 5 {
-		return nil, ErrInvalidFormat
+	dstIP, err := parseAddress(parts[3], headerProtocol)
+	if err != nil {
+		return nil, fmt.Errorf("%w %s: %w", ErrParseDestinationAddress, parts[3], err)
 	}
-	sport, ok := convertPort(sportInt)
+	sport, ok := convertPort(parts[4])
 	if !ok {
-		return nil, fmt.Errorf("%w %d", ErrInvalidSourcePort, sport)
+		return nil, fmt.Errorf("%w %s", ErrInvalidSourcePort, parts[4])
 	}
-	dport, ok := convertPort(dportInt)
+	dport, ok := convertPort(parts[5])
 	if !ok {
-		return nil, fmt.Errorf("%w %d", ErrInvalidDestinationPort, dport)
-	}
-	srcIP, err := netip.ParseAddr(src)
-	if err != nil {
-		return nil, fmt.Errorf("%w %s: %w", ErrParseSourceAddress, src, err)
-	}
-	dstIP, err := netip.ParseAddr(dst)
-	if err != nil {
-		return nil, fmt.Errorf("%w %s: %w", ErrParseDestinationAddress, dst, err)
+		return nil, fmt.Errorf("%w %s", ErrInvalidDestinationPort, parts[5])
 	}
 
 	return &proxyHeader{
@@ -222,8 +216,20 @@ func ReadRemoteAddr(buf []byte, protocol utils.Protocol) (*proxyHeader, error) {
 	return nil, ErrProxyProtocolMissing
 }
 
-func convertPort(port int) (uint16, bool) {
-	if port <= 0 || port > 65535 {
+func parseAddress(addrStr, protocol string) (netip.Addr, error) {
+	ipAddr, err := netip.ParseAddr(addrStr)
+	if err != nil {
+		return ipAddr, fmt.Errorf("%w: %w", ErrParseAddress, err)
+	}
+	if ipAddr.Is4() != (protocol == "TCP4") {
+		return ipAddr, ErrProtocolAddrMismatch
+	}
+	return ipAddr, nil
+}
+
+func convertPort(portStr string) (uint16, bool) {
+	port, err := strconv.ParseUint(portStr, 10, 16)
+	if err != nil || port <= 0 || port > 65535 {
 		return 0, false
 	}
 	return uint16(port), true

--- a/internal/proxyprotocol/proxyprotocol_test.go
+++ b/internal/proxyprotocol/proxyprotocol_test.go
@@ -5,6 +5,7 @@
 package proxyprotocol_test
 
 import (
+	"errors"
 	"net/netip"
 	"reflect"
 	"testing"
@@ -85,6 +86,27 @@ func TestProxyProtocolV1_UnknownWithAddrs(t *testing.T) {
 	}
 }
 
+func TestProxyProtocolV1_ExtraTokens(t *testing.T) {
+	buf := []byte("PROXY TCP4 192.168.0.1 192.168.0.11 56324 443 extra\r\nmoredata")
+
+	proxyHeader, err := proxyprotocol.ReadRemoteAddr(buf, utils.TCP)
+	if err == nil {
+		t.Errorf("Error was expected, yet returned %v", proxyHeader)
+	}
+}
+
+func TestProxyProtocolV1_ProtocolAddrMismatch(t *testing.T) {
+	buf := []byte("PROXY TCP4 2001:db8::1 2001:db8::2 56324 443\r\nmoredata")
+
+	proxyHeader, err := proxyprotocol.ReadRemoteAddr(buf, utils.TCP)
+	if err == nil {
+		t.Errorf("Error was expected, yet returned %v", proxyHeader)
+	}
+	if !errors.Is(err, proxyprotocol.ErrProtocolAddrMismatch) {
+		t.Errorf("Unexpected error: %v", err)
+	}
+}
+
 func TestProxyProtocolV2(t *testing.T) {
 	buf := []byte{0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D, 0x0A, 0x51, 0x55, 0x49, 0x54, 0x0A}
 	buf = append(buf, 0x21)            // PROXY
@@ -111,6 +133,40 @@ func TestProxyProtocolV2(t *testing.T) {
 
 	if !reflect.DeepEqual(proxyHeader.TrailingData, []byte("moredata")) {
 		t.Errorf("Unexpected rest: %v", proxyHeader.TrailingData)
+	}
+}
+
+func TestProxyProtocolV2_ShortIPv4AddressData(t *testing.T) {
+	buf := []byte{0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D, 0x0A, 0x51, 0x55, 0x49, 0x54, 0x0A}
+	buf = append(buf, 0x21)                  // PROXY
+	buf = append(buf, 0x11)                  // TCP4
+	buf = append(buf, 0x00, 0x08)            // 8 bytes
+	buf = append(buf, 192, 168, 0, 1)        // saddr
+	buf = append(buf, 192, 168, 0, 11)       // daddr
+	buf = append(buf, []byte("moredata")...) // trailing data
+
+	proxyHeader, err := proxyprotocol.ReadRemoteAddr(buf, utils.TCP)
+	if err == nil {
+		t.Errorf("Error was expected, yet returned %v", proxyHeader)
+	}
+	if !errors.Is(err, proxyprotocol.ErrInvalidAddressDataLength) {
+		t.Errorf("Unexpected error: %v", err)
+	}
+}
+
+func TestProxyProtocolV2_ZeroAddressDataLength(t *testing.T) {
+	buf := []byte{0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D, 0x0A, 0x51, 0x55, 0x49, 0x54, 0x0A}
+	buf = append(buf, 0x21)       // PROXY
+	buf = append(buf, 0x11)       // TCP4
+	buf = append(buf, 0x00, 0x00) // 0 bytes
+	buf = append(buf, []byte("moredata")...)
+
+	proxyHeader, err := proxyprotocol.ReadRemoteAddr(buf, utils.TCP)
+	if err == nil {
+		t.Errorf("Error was expected, yet returned %v", proxyHeader)
+	}
+	if !errors.Is(err, proxyprotocol.ErrInvalidAddressDataLength) {
+		t.Errorf("Unexpected error: %v", err)
 	}
 }
 
@@ -143,5 +199,25 @@ func TestProxyProtocolV2_udp6(t *testing.T) {
 
 	if !reflect.DeepEqual(proxyHeader.TrailingData, []byte("moredata")) {
 		t.Errorf("Unexpected rest: %v", proxyHeader.TrailingData)
+	}
+}
+
+func TestProxyProtocolV2_ShortIPv6AddressData(t *testing.T) {
+	expectedSaddr := netip.MustParseAddr("2001:db8::1")
+	expectedDaddr := netip.MustParseAddr("2001:db8::2")
+
+	buf := []byte{0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D, 0x0A, 0x51, 0x55, 0x49, 0x54, 0x0A}
+	buf = append(buf, 0x21)       // PROXY
+	buf = append(buf, 0x22)       // UDP6
+	buf = append(buf, 0x00, 0x20) // 32 bytes
+	buf = append(buf, expectedSaddr.AsSlice()...)
+	buf = append(buf, expectedDaddr.AsSlice()...)
+
+	proxyHeader, err := proxyprotocol.ReadRemoteAddr(buf, utils.UDP)
+	if err == nil {
+		t.Errorf("Error was expected, yet returned %v", proxyHeader)
+	}
+	if !errors.Is(err, proxyprotocol.ErrInvalidAddressDataLength) {
+		t.Errorf("Unexpected error: %v", err)
 	}
 }

--- a/internal/setsockopt/setsockopt.go
+++ b/internal/setsockopt/setsockopt.go
@@ -23,64 +23,71 @@ var (
 // Parent error
 var ErrSetsockopt = errors.New("setsockopt")
 
-func TCPSynCnt(fd uintptr, value int) error {
-	err := syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, syscall.TCP_SYNCNT, value)
+func TCPSynCnt(fdUintptr uintptr, value int) error {
+	fd := int(fdUintptr) // #nosec G115
+	err := syscall.SetsockoptInt(fd, syscall.IPPROTO_TCP, syscall.TCP_SYNCNT, value)
 	if err != nil {
 		return fmt.Errorf("%w(%w, %d): %w", ErrSetsockopt, ErrTCPSynCnt, value, err)
 	}
 	return nil
 }
 
-func IPTransparent(fd uintptr, transparent bool) error {
+func IPTransparent(fdUintptr uintptr, transparent bool) error {
+	fd := int(fdUintptr) // #nosec G115
 	value := boolToInt(transparent)
-	err := syscall.SetsockoptInt(int(fd), syscall.IPPROTO_IP, syscall.IP_TRANSPARENT, value)
+	err := syscall.SetsockoptInt(fd, syscall.IPPROTO_IP, syscall.IP_TRANSPARENT, value)
 	if err != nil {
 		return fmt.Errorf("%w(%w, %d): %w", ErrSetsockopt, ErrIPTransparent, value, err)
 	}
 	return nil
 }
 
-func ReuseAddr(fd uintptr, reuseAddr bool) error {
+func ReuseAddr(fdUintptr uintptr, reuseAddr bool) error {
+	fd := int(fdUintptr) // #nosec G115
 	value := boolToInt(reuseAddr)
-	err := syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_REUSEADDR, value)
+	err := syscall.SetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_REUSEADDR, value)
 	if err != nil {
 		return fmt.Errorf("%w(%w, %d): %w", ErrSetsockopt, ErrReuseAddr, value, err)
 	}
 	return nil
 }
 
-func ReusePort(fd uintptr, reusePort bool) error {
+func ReusePort(fdUintptr uintptr, reusePort bool) error {
+	fd := int(fdUintptr) // #nosec G115
 	value := boolToInt(reusePort)
 	soReusePort := 15
-	err := syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, soReusePort, value)
+	err := syscall.SetsockoptInt(fd, syscall.SOL_SOCKET, soReusePort, value)
 	if err != nil {
 		return fmt.Errorf("%w(%w, %d): %w", ErrSetsockopt, ErrReusePort, value, err)
 	}
 	return nil
 }
 
-func IPBindAddressNoPort(fd uintptr, bindAddressNoPort bool) error {
+func IPBindAddressNoPort(fdUintptr uintptr, bindAddressNoPort bool) error {
+	fd := int(fdUintptr) // #nosec G115
 	value := boolToInt(bindAddressNoPort)
 	ipBindAddressNoPort := 24
-	err := syscall.SetsockoptInt(int(fd), syscall.IPPROTO_IP, ipBindAddressNoPort, value)
+	err := syscall.SetsockoptInt(fd, syscall.IPPROTO_IP, ipBindAddressNoPort, value)
 	if err != nil {
 		return fmt.Errorf("%w(%w, %d): %w", ErrSetsockopt, ErrIPBindAddressNoPort, value, err)
 	}
 	return nil
 }
 
-func SoMark(fd uintptr, mark int) error {
+func SoMark(fdUintptr uintptr, mark int) error {
+	fd := int(fdUintptr) // #nosec G115
 	value := mark
-	err := syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_MARK, value)
+	err := syscall.SetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_MARK, value)
 	if err != nil {
 		return fmt.Errorf("%w(%w, %d): %w", ErrSetsockopt, ErrSoMark, value, err)
 	}
 	return nil
 }
 
-func IPv6V6Only(fd uintptr, v6Only bool) error {
+func IPv6V6Only(fdUintptr uintptr, v6Only bool) error {
+	fd := int(fdUintptr) // #nosec G115
 	value := boolToInt(v6Only)
-	err := syscall.SetsockoptInt(int(fd), syscall.IPPROTO_IPV6, syscall.IPV6_V6ONLY, value)
+	err := syscall.SetsockoptInt(fd, syscall.IPPROTO_IPV6, syscall.IPV6_V6ONLY, value)
 	if err != nil {
 		return fmt.Errorf("%w(%w, %d): %w", ErrSetsockopt, ErrIPv6V6Only, value, err)
 	}

--- a/internal/udp/udp.go
+++ b/internal/udp/udp.go
@@ -60,12 +60,13 @@ func copyFromBackend(frontendConn net.PacketConn, connInfo *connectionInfo, conf
 
 	var syscallErr error
 
-	err = rawConn.Read(func(fd uintptr) bool {
+	err = rawConn.Read(func(fdUintptr uintptr) bool {
 		buf := config.BufferPool.Get()
 		defer config.BufferPool.Put(buf)
 
 		for {
-			numBytesRead, _, serr := syscall.Recvfrom(int(fd), buf, syscall.MSG_DONTWAIT)
+			fd := int(fdUintptr) // #nosec G115
+			numBytesRead, _, serr := syscall.Recvfrom(fd, buf, syscall.MSG_DONTWAIT)
 			if errors.Is(serr, syscall.EWOULDBLOCK) {
 				return false
 			}


### PR DESCRIPTION
Add additional checks for PROXY headers.
Even if proxy is meant to run on trusted inputs,
we don't want to crash the process on invalid
client implementations.

Thanks to @speziato for flagging the issue!